### PR TITLE
Using different than bck2brwsr.js name for the main application script

### DIFF
--- a/bck2brwsr/client-web/pom.xml
+++ b/bck2brwsr/client-web/pom.xml
@@ -22,7 +22,7 @@
         <browser.bootstrap>initialize bck2brwsr --&gt;
 &lt;script type="text/javascript" src="bck2brwsr.js"&gt;&lt;/script&gt;
 &lt;script&gt;
-    var vm = bck2brwsr('bck2brwsr.js');
+    var vm = bck2brwsr('bck2brwsr-web.js');
     var c = vm.loadClass('com.athaydes.BrowserMain');
     c.invoke('main');
 &lt;/script&gt;
@@ -87,7 +87,7 @@
                     <directory>${project.build.directory}/${project.build.finalName}-bck2brwsr/public_html/</directory>
                     <startpage>index.html</startpage>
                     <classPathPrefix>lib</classPathPrefix>
-                    <mainJavaScript>${project.build.directory}/bck2brwsr.js</mainJavaScript>
+                    <mainJavaScript>${project.build.directory}/bck2brwsr-web.js</mainJavaScript>
                     <exports>
                         <export>${project.mainclass}</export>
                     </exports>


### PR DESCRIPTION
Thanks for giving [DukeScript](http://dukescript.com)+[bck2brwsr](http://bck2brwsr.apidesign.org) a try. The selected artifact name `bck2brwsr` is a challenge - it clashes with the name of the main launcher file `target/bck2brwsr.js`. The build script overrides one with the other and then the application doesn't start. With the proposed manual change to `bck2brwsr-web.js` you should be able to launch the application (`cd jvm-alternatives-to-js/bck2brwsr; mvn install; mvn -f client-web/ bck2brwsr:show`) and continue in your experiments.

Good luck and thanks again.